### PR TITLE
Fix urlconf to avoid string view arguments to url()

### DIFF
--- a/src/urls.py
+++ b/src/urls.py
@@ -22,9 +22,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from django.conf.urls import *
+from django.conf.urls import url
+
+from .views import view_all, flush
 
 urlpatterns = [
-    url(r'^view_all/?$', 'argcache.views.view_all', name='view_all'),
-    url(r'^flush/([0-9]+)/?$', 'argcache.views.flush', name='flush')
+    url(r'^view_all/?$', view_all, name='view_all'),
+    url(r'^flush/([0-9]+)/?$', flush, name='flush')
 ]


### PR DESCRIPTION
I tested this with my ESP website checkout since the argcache tests don't cover this. It works.
